### PR TITLE
feat: Add Discord command to manually stop Game Server

### DIFF
--- a/resources/discord-bot-asl.json
+++ b/resources/discord-bot-asl.json
@@ -13,7 +13,12 @@
         {
           "Variable": "$.SubCommand",
           "StringEquals": "start",
-          "Next": "UpdateService"
+          "Next": "StartService"
+        },
+        {
+          "Variable": "$.SubCommand",
+          "StringEquals": "stop",
+          "Next": "StopService"
         }
       ],
       "Default": "WutMessage"
@@ -26,7 +31,7 @@
       },
       "ResultPath": "$.Discord"
     },
-    "UpdateService": {
+    "StartService": {
       "Type": "Task",
       "Next": "RunningCheck",
       "Parameters": {
@@ -67,6 +72,21 @@
         "Message": "Server is starting, give it 10 minutes"
       },
       "ResultPath": "$.Discord"
+    },
+    "StopService": {
+      "Type": "Task",
+      "Next": "DescribeServices",
+      "Parameters": {
+        "Cluster": "",
+        "Service": "",
+        "DesiredCount": 0
+      },
+      "Resource": "arn:aws:states:::aws-sdk:ecs:updateService",
+      "ResultSelector": {
+        "DesiredCount.$": "$.Service.DesiredCount",
+        "RunningCount.$": "$.Service.RunningCount"
+      },
+      "ResultPath": "$.Service"
     },
     "DescribeServices": {
       "Type": "Task",

--- a/resources/functions/discord_provider/discord_provider.py
+++ b/resources/functions/discord_provider/discord_provider.py
@@ -35,6 +35,11 @@ def on_create(event):
                 "description": "Start the server, if it isn't running",
                 "type": 1,
             },
+            {
+                "name": "stop",
+                "description": "Stop the server, if it is running",
+                "type": 1,
+            },
         ],
     }
 

--- a/src/discord-state-machine.ts
+++ b/src/discord-state-machine.ts
@@ -51,11 +51,18 @@ export class DiscordStateMachine extends Construct {
             ],
           },
         },
-        UpdateService: {
+        StartService: {
           Parameters: {
             Cluster: props.service.cluster.clusterArn,
             Service: props.service.serviceArn,
             DesiredCount: 1,
+          },
+        },
+        StopService: {
+          Parameters: {
+            Cluster: props.service.cluster.clusterArn,
+            Service: props.service.serviceArn,
+            DesiredCount: 0,
           },
         },
         SendDiscordResponse: {


### PR DESCRIPTION
Allows the server to manually be stopped via Discord, instead of waiting for the auto-shutdown. 